### PR TITLE
feat: allow more version formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@ temporalts is a module that leverages [Moment](https://www.npmjs.com/package/mom
 ## Installation
 
 ```
-npm install timelts
+npm install temporalts
 ```
 
 ## Usage
 
 temporalts can pass all Node.js LTS release line temporal information, or the temporal information for a _specific_ release line.
 
-### `temporalts()` (all release line temporal information)
+### `temporalts()`
 
-This will return a Promise that resolves an object where each key is the name of a release line and the property of each key is an object that includes several instances of Moment and some additional useful information that is derived from those instances of Moment.
+Returns `Promise<Object>` -  an object where each key is the name of a release line and the property of each key is an object that includes several instances of Moment and some additional useful information that is derived from those instances of Moment.
 
+Example:
 ```js
 const temporalts = require('temporalts')
 
@@ -32,59 +33,24 @@ timeUntilEachLineGoesEOL()
 
 ### `temporalts(version)` (release line temporal information for `version`)
 
-You can pass a version as an argument to `temporalts()` that will then only resolve the specific Node.js LTS release line you requested, rather than an object of all versions. There are a few caveats:
+* `version` String - A string representing a maintained release line format. Must be in a recognizable version format, or an error will be thrown.
+  * Valid examples for Node.js' `v12` release line would include: `v12`, `12`, `v12.x`, `12.x.y`, `12.x`, or `v12.x.y`.
 
-- You must only pass versions that map to an LTS release line. In Node.js, all even versions were, are, or will be LTS release lines.
-- You must preface the version with a `v`. For example, `v12`, `v6`, `v14`.
-- You must only pass versions that exist in the [`schedule.json`](https://github.com/nodejs/Release/blob/master/schedule.json) file the Node.js Release WG maintains. Generally, it seems this is 1 LTS ahead of the currently published version that _is_ or _will be_ an LTS version.
-
-
-```js
-const temporalts = require('../')
-
-async function prettyPrint () {
-  const version = 'v12'
-    const data = await temporalts(version)
-
-    console.log
-    console.log(`We are ${data.currentPercentOfLTSLifeSpanWithoutDecimal}% through the lifespan of the Node.js ${version} LTS release line.\n${data.currentPercentOfLTSLifeSpanAsProgressBar}`)
-    console.log()
-}
-
-prettyPrint()
-```
-#### Examples of What **Will** Work When Passing a Version
-
-- `v4`, `v6`, `v8`, `v10`, `v12`, `v14`
-
-#### Examples of What **Will Not** Work When Passing a Version
-
-- `6`, `8`, `10`, `12`
-- `v7`, `v9`, `v11`, `v13`
-- `6.0.0`, `12.0.0`
-- `v6.0.0`, `v12.0.0`
-- `8.x`, `10.x`
-- `v8.x`, `v10.x`
-- `v30`
-
-## Exposed API
-
-Once resolved, the temporalts promise returns an object. It provides this shape:
-
-- `now`: An instance of `moment()` which is the current moment in time.
-- `timeframeStart`: An instance of `moment` that is the beginning of the LTS window of a given release's lifespan.
-  - **Important:** This is *not* the original release of the LTS release line as Current, but rather the moment it moved from Current to LTS.
-- `timeframeEnd`: An instance of `moment` that is the moment a given release line goes End of Life (EOL).
-- `diffStartAndEnd`: Difference (in milliseconds) between `timeframeStart` and `timeframeEnd`.
-- `diffNowAndStart`: Difference (in milliseconds) between `now` and `timeframeStart`.
-- `diffNowAndEnd`: Difference (in milliseconds) between `now` and `timeframeEnd`.
-- `onePercentOfLTSLifeSpanInMilliseconds`: A calculation (in milliseconds) of 1% of the lifespan of a given release.
-- `onePercentOfLTSLifeSpanInDays`: A calculation (in days) of 1% of the lifespan of a given release.
-- `currentPercentOfLTSLifeSpan`: Gives the raw (including decimal) percentage of time that has passed from the beginning to the end of a given release's LTS lifespan.
-- `currentPercentOfLTSLifeSpanWithoutDecimal`: Gives the more human-friendly (exclusing decimal) percentage of time that has passed from the beginning to the end of a given release's LTS lifespan.
-- `currentPercentOfLTSLifeSpanAsProgressBar`: Proives a progress bar (using the charachters `[`, `=`, ` `, and `]`) that shows the current progress of a given release's lifespan in a visual format.
-- `fromNowToEnd`: Human-readable time from now to the end of the LTS window.
-- `fromLTSStartToNow`: Human-readable time from the start of the LTS window to now.
+Returns `Promise<Object>` - resolves an Object containing the following properties:
+  - `now`: An instance of `moment()` which is the current moment in time.
+  - `timeframeStart`: An instance of `moment` that is the beginning of the LTS window of a given release's lifespan.
+    - **Important:** This is *not* the original release of the LTS release line as Current, but rather the moment it moved from Current to LTS.
+  - `timeframeEnd`: An instance of `moment` that is the moment a given release line goes End of Life (EOL).
+  - `diffStartAndEnd`: Difference (in milliseconds) between `timeframeStart` and `timeframeEnd`.
+  - `diffNowAndStart`: Difference (in milliseconds) between `now` and `timeframeStart`.
+  - `diffNowAndEnd`: Difference (in milliseconds) between `now` and `timeframeEnd`.
+  - `onePercentOfLTSLifeSpanInMilliseconds`: A calculation (in milliseconds) of 1% of the lifespan of a given release.
+  - `onePercentOfLTSLifeSpanInDays`: A calculation (in days) of 1% of the lifespan of a given release.
+  - `currentPercentOfLTSLifeSpan`: Gives the raw (including decimal) percentage of time that has passed from the beginning to the end of a given release's LTS lifespan.
+  - `currentPercentOfLTSLifeSpanWithoutDecimal`: Gives the more human-friendly (exclusing decimal) percentage of time that has passed from the beginning to the end of a given release's LTS lifespan.
+  - `currentPercentOfLTSLifeSpanAsProgressBar`: Proives a progress bar (using the charachters `[`, `=`, ` `, and `]`) that shows the current progress of a given release's lifespan in a visual format.
+  - `fromNowToEnd`: Human-readable time from now to the end of the LTS window.
+  - `fromLTSStartToNow`: Human-readable time from the start of the LTS window to now.
 
 Below is an example of **of one entry**. You will get several of these as properties of their respective versions as keys if you execute the module without passing a version.
 
@@ -103,5 +69,27 @@ Below is an example of **of one entry**. You will get several of these as proper
     "currentPercentOfLTSLifeSpanAsProgressBar": "[=========           ]",
     "fromNowToEnd": "in a year",
     "fromLTSStartToNow": "a year ago"
-  }
-  ```
+}
+```   
+
+- You must only pass versions that map to an LTS release line. In Node.js, all even versions were, are, or will be LTS release lines.
+- Data will only be returned for versions that exist in the [`schedule.json`](https://github.com/nodejs/Release/blob/master/schedule.json) file the Node.js Release WG maintains.
+  - Generally, this is 1 LTS ahead of the currently published version that _is_ or _will be_ an LTS version.
+
+Example:
+```js
+const temporalts = require('../')
+
+async function prettyPrint () {
+  const version = 'v12'
+  const data = await temporalts(version)
+
+  const percentDecimal = data.currentPercentOfLTSLifeSpanWithoutDecimal
+  const percentProgress = data.currentPercentOfLTSLifeSpanAsProgressBar
+  console.log(`We are ${percent}% through the lifespan of the Node.js ${version} LTS release line.\n`)
+  console.log(percentProgress)
+}
+
+prettyPrint()
+```
+

--- a/helpers/fetchSchedule.js
+++ b/helpers/fetchSchedule.js
@@ -12,4 +12,4 @@ async function fetchSchedule (url) {
   }
 }
 
-module.exports = fetchSchedule
+module.exports.fetchSchedule = fetchSchedule

--- a/helpers/percentage.js
+++ b/helpers/percentage.js
@@ -31,4 +31,4 @@ async function buildPercentage (decimal) {
   return result
 }
 
-module.exports = buildPercentage
+module.exports.buildPercentage = buildPercentage

--- a/helpers/version.js
+++ b/helpers/version.js
@@ -1,0 +1,32 @@
+/**
+ * Sanitizes a release line string in Node.js, and allows for passing
+ * a version number in a variety of formats.
+ * 
+ * Examples (input -> output):
+ * 'v12' -> 'v12'
+ * '12' -> 'v12'
+ * '12.x' -> 'v12'
+ * 'v12.x' -> 'v12'
+ * 'v12.x.y' -> 'v12'
+ *
+ * @param version - a raw string representing a release line in Node.js.
+ * @returns a sanitized version string in e.g. 'v12' format
+ */
+function parseVersion (version) {
+  if (version === 'all') return version
+
+  // Return if the version is already in valid format (ex. v12)
+  if (/^v[0-9]{2}$/.test(version)) return version
+
+  // If the version is just a number (ex. 12), prepend a 'v'
+  if (/^[0-9]{2}$/.test(version)) return `v${version}`
+
+  // If version matches e.g. 12.x, v12.x, v12.x.y, or 12.x.y
+  // pull out the version number and prepend with 'v'
+  const match = version.match(/v?(\d{2})(.x|.x.y)/)
+  if (match) return `v${match[1]}`
+
+  throw new Error(`${version} is not in an acceptable format`)
+}
+
+module.exports.parseVersion = parseVersion

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const lts = require('exports/lts.js')
+const lts = require('./exports/lts.js')
 
 module.exports = lts

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "main": "exports/lts.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [
     "lts",
@@ -28,7 +28,9 @@
   "directories": {
     "example": "examples"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mocha": "^6.2.2"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cutenode/temporalts.git"

--- a/test/version.spec.js
+++ b/test/version.spec.js
@@ -1,0 +1,24 @@
+const assert = require('assert')
+const { parseVersion } = require('../helpers/version')
+
+describe('parseVersion(version)', () => {
+  it('throws an error for badly formed versions', () => {
+    const badVersion = 'i-am-a-bad-version'
+    assert.throws(() => {
+      parseVersion(badVersion)
+    }, /^Error: i-am-a-bad-version is not in an acceptable format$/)
+  })
+
+  it(`returns 'all' when 'all' is passed`, () => {
+    const parsed = parseVersion('all')
+    assert.equal(parsed, 'all')
+  })
+
+  it('correctly sanitizes valid versions', () => {
+    const versions = ['v12', '12', 'v12.x', '12.x', 'v12.x.y', '12.x.y']
+    for (const version of versions) {
+      const sanitized = parseVersion(version)
+      assert.equal(sanitized, 'v12')
+    }
+  })
+})


### PR DESCRIPTION
Allows for a wider variety of version formats to be successfully passed to the primary `temporalts` function. I also updated a few things in documentation to make it clearer what the parameter and return values were for the functions. I also considered consolidating the two `temporalts` API sections into one since they're the same API but i wasn't sure the intentionality behind that so i left it as-is for now but can also change that.

cc @bnb 